### PR TITLE
Replace PropTypes from React with form prop-types package

### DIFF
--- a/ListViewSelect.js
+++ b/ListViewSelect.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import {
   ListView,
-  PropTypes,
   StyleSheet,
   Text,
   Dimensions,
   TouchableOpacity,
   View,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const noop = () => {};

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/JamesWatling/react-native-list-view-select/issues"
   },
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "homepage": "https://github.com/JamesWatling/react-native-list-view-select"
 }


### PR DESCRIPTION
See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes
Also seems to be breaking on react@16.0.0-beta.5 and react-native@0.49.3